### PR TITLE
Additional Error Plot and Lat/Lon Shift for savegrid

### DIFF
--- a/gridTools/lib/app.py
+++ b/gridTools/lib/app.py
@@ -21,6 +21,8 @@ pn.extension()
 class App:
 
     def __init__(self, grd=None):
+        # Locals
+        self.gridMade = False
         # Globals
         
         # This application has its own copy of GridTools() object
@@ -268,12 +270,38 @@ class App:
             msg = "Running make_plot(): done"     
             self.grd.printMsg(msg, logging.INFO)
         else:
-            (figure, axes) = self.errorFigure()
-            msg = "Running make_plot(): plotting failure"
-            self.grd.printMsg(msg, logging.ERROR)
-
+            if self.gridMade == False:
+                (figure, axes) = self.errorNoGridFigure()
+                msg = "Running make_plot(): plotting failure - unspecified grid."
+                self.grd.printMsg(msg, logging.ERROR)
+            else:
+                (figure, axes) = self.errorFigure()
+                msg = "Running make_plot(): plotting failure"
+                self.grd.printMsg(msg, logging.ERROR)
         return figure
 
+    
+    def errorNoGridFigure(self):
+        '''Creates a plot for the scenario where the user has not specified the grid before making a plot'''
+        
+        f = self.grd.newFigure()
+        central_longitude = self.grd.getPlotParameter('lon_0', subKey='projection', default=0.0)
+        central_latitude = self.grd.getPlotParameter('lat_0', subKey='projection', default=90.0)
+        satellite_height = self.grd.getPlotParameter('satellite_height', default=35785831)
+        crs = cartopy.crs.NearsidePerspective(central_longitude=central_longitude, central_latitude=central_latitude, satellite_height=satellite_height)
+        ax = f.subplots(subplot_kw={'projection': crs})
+        if self.grd.usePaneMatplotlib:
+            FigureCanvas(f)
+        mapExtent = self.grd.getPlotParameter('extent', default=[])
+        mapCRS = self.grd.getPlotParameter('extentCRS', default=cartopy.crs.PlateCarree())
+        ax.set_global()
+        ax.coastlines()
+        ax.gridlines()
+        ax.set_title("Unspecified Grid", color='red')
+        ax.text(0.5, 0.55, 'please create your grid before plotting', transform=ax.transAxes,
+                fontsize=10, color='blue', alpha=0.4,
+                ha='center', va='center', rotation='0')
+        return f, ax
     
     def errorFigure(self):
         '''Create Blank Plot to signal plotting failure. This signals a problem within the user specifications in relation to code capabilities.  '''
@@ -292,8 +320,8 @@ class App:
         ax.coastlines()
         ax.gridlines()
         ax.set_title("Plot Failure", color='red')
-        ax.text(0.5, 0.4, 'please check plot/grid parameters and retry', transform=ax.transAxes,
-                fontsize=10, color='red', alpha=0.2,
+        ax.text(0.5, 0.55, 'please check plot/grid parameters and retry', transform=ax.transAxes,
+                fontsize=10, color='red', alpha=0.4,
                 ha='center', va='center', rotation='0')
         return f, ax
     

--- a/gridTools/lib/app.py
+++ b/gridTools/lib/app.py
@@ -21,8 +21,7 @@ pn.extension()
 class App:
 
     def __init__(self, grd=None):
-        # Locals
-        self.gridMade = False
+
         # Globals
         
         # This application has its own copy of GridTools() object
@@ -270,7 +269,7 @@ class App:
             msg = "Running make_plot(): done"     
             self.grd.printMsg(msg, logging.INFO)
         else:
-            if self.gridMade == False:
+            if self.grd.gridMade == False:
                 (figure, axes) = self.errorNoGridFigure()
                 msg = "Running make_plot(): plotting failure - unspecified grid."
                 self.grd.printMsg(msg, logging.ERROR)

--- a/gridTools/lib/gridutils.py
+++ b/gridTools/lib/gridutils.py
@@ -1012,7 +1012,9 @@ class GridUtils:
         '''
         if filename:
             self.xrFilename = filename
-            
+            if self.grid.x.attrs['units'] == 'degrees_east':
+                self.grid.x.values = np.where(self.grid.x.values>180, self.grid.x.values-360, self.grid.x.values)
+            self.grid.to_netcdf(self.xrFilename, encoding=self.removeFillValueAttributes())
         try:
             self.grid.to_netcdf(self.xrFilename, encoding=self.removeFillValueAttributes())
             msg = "Successfully wrote netCDF file to %s" % (self.xrFilename)

--- a/gridTools/lib/gridutils.py
+++ b/gridTools/lib/gridutils.py
@@ -37,6 +37,8 @@ class GridUtils:
         self.msgBox = None
         # Private variables begin with a _
         # Grid parameters
+        # Locals
+        self.gridMade = False
         self.gridInfo = {}
         self.gridInfo['dimensions'] = {}
         self.gridInfo['gridParameters'] = {}


### PR DESCRIPTION
1) Added `errorNoGridFigure` to `app.py` 
    - This function shows an error plot in the event that a user attempts to create a plot without creating a grid first
    - A more descriptive message for the logger has also been created

2) Added clause to `saveGrid` in `gridUtils.py` to convert longitudinal degrees from 0:360 to -180:180
    - This is a piece to close this "to do" line > **_on saveGrid() convert lon [+0,+360] to [-180,+180]_**

